### PR TITLE
Added access tokens inside cookies for WebSocket and SSEs

### DIFF
--- a/services/auth/src/main/java/org/acme/api/AuthResource.java
+++ b/services/auth/src/main/java/org/acme/api/AuthResource.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.acme.dto.AdminUpdateDTO;
 import org.acme.dto.SessionDTO;
 import org.acme.dto.UserInfoDTO;
+import org.acme.dto.UserResponseDTO;
 import org.acme.dto.UserSummaryDTO;
 import org.acme.dto.UserUpdateDTO;
 import org.acme.service.AdminService;
@@ -62,22 +63,36 @@ public class AuthResource {
 	@GET
 	@Path("/login/{provider}")
 	@Authenticated
-	public Response login(@PathParam("provider") String provider) {
-		return Response.status(200)
-			.entity(authService.createToken(identity))
+	public Response login(
+						@PathParam("provider") @DefaultValue("google") String provider,
+						@QueryParam("isCookie") @DefaultValue("true") Boolean isCookie) {
+		UserResponseDTO userResponse = authService.createToken(identity);
+		Response.ResponseBuilder responseBuilder = Response
+			.status(200)
+			.entity(userResponse)
 			.cookie(authService.createSessionCookie(identity))
-			.cookie(authService.clearOIDCCookies())
-			.build();
+			.cookie(authService.clearOIDCCookies());
+		if (isCookie)
+			responseBuilder.cookie(authService.createAccessTokenCookie(userResponse.accessToken));
+
+		return responseBuilder.build();
 	}
 
 	// To refresh the user after access token expires
 	@POST
 	@Path("/refresh")
 	@PermitAll
-	public Response refresh(@CookieParam("sessionId") String sessionId) {
-		return Response.status(200)
-			.entity(authService.refreshToken(sessionId))
-			.build();
+	public Response refresh(
+						@CookieParam("sessionId") String sessionId,
+						@QueryParam("isCookie") @DefaultValue("true") Boolean isCookie) {
+		UserResponseDTO userResponse = authService.refreshToken(sessionId);
+		Response.ResponseBuilder responseBuilder = Response
+			.status(200)
+			.entity(userResponse);
+		if (isCookie)
+			responseBuilder.cookie(authService.createAccessTokenCookie(userResponse.accessToken));
+
+		return responseBuilder.build();
 	}
 
 	// To Logout the user from the current session, or a specific session

--- a/services/auth/src/main/java/org/acme/service/AuthService.java
+++ b/services/auth/src/main/java/org/acme/service/AuthService.java
@@ -160,6 +160,20 @@ public class AuthService {
 		return new NewCookie[] { clearDefault, clearGoogle, clear42 };
 	}
 
+	public NewCookie createAccessTokenCookie(String accessToken) {
+		return new NewCookie.Builder("accessToken")
+			.value(accessToken)
+			.path("/")
+			.domain(domain)
+			.expiry(Date.from(Instant.now().plusSeconds(accessExpiry)))
+			.maxAge(accessExpiry.intValue())
+			.sameSite(NewCookie.SameSite.LAX)
+			.secure(secureCookies)
+			.httpOnly(true)
+			.comment("The access token for websocket and SSE use")
+			.build();
+	}
+
 	@Transactional
 	public UserResponseDTO refreshToken(String sessionId) {
 		if (sessionId == null || sessionId.isEmpty()) {

--- a/services/gateway/src/main/resources/application.properties
+++ b/services/gateway/src/main/resources/application.properties
@@ -62,7 +62,7 @@ mp.jwt.verify.issuer=https://${DOMAIN_NAME:localhost}
 # smallrye.jwt.token.header=Authorization
 # smallrye.jwt.token.cookie=sessionId
 mp.jwt.token.header=Authorization
-mp.jwt.token.cookie=sessionId
+mp.jwt.token.cookie=accessToken
 
 # If you want to enable RBAC
 # quarkus.http.auth.permission.authenticated.paths=/api/*


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Authentication endpoints now accept an optional cookie preference parameter to control access token cookie usage (defaults to enabled)
  * Login endpoint now defaults to Google when no provider is specified
  * Added access token cookie support to the authentication flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->