### PR TITLE
fix: field error message not resseting, and added regex to full name …

### DIFF
--- a/services/web/src/features/auth/ui/settings/SettingsPage.tsx
+++ b/services/web/src/features/auth/ui/settings/SettingsPage.tsx
@@ -308,7 +308,7 @@ export default function SettingsPage({
 			createUserSchema.safeParse({
 				username: newUserForm.username,
 				fullName: newUserForm.fullName,
-				email: newUserForm.overflowEmail,
+				overflowEmail: newUserForm.overflowEmail,
 				bio: newUserForm.bio ?? '',
 				role: newUserForm.role,
 				isBanned: newUserForm.isBanned,
@@ -322,12 +322,19 @@ export default function SettingsPage({
 			newUserForm.username,
 		]
 	);
-	const createUserValidationMessage = !createUserValidation.success
-		? createUserValidation.error.issues[0]?.message || 'Invalid input'
-		: null;
-	const createUserDisplayMessage = createUserSubmitAttempted
-		? createUserValidationMessage
-		: null;
+	const createUserFieldErrors = useMemo(() => {
+		if (!createUserSubmitAttempted || createUserValidation.success) {
+			return {} as Partial<Record<keyof CreateUserPayload, string>>;
+		}
+		const fieldErrors: Partial<Record<keyof CreateUserPayload, string>> = {};
+		for (const issue of createUserValidation.error.issues) {
+			const field = issue.path[0] as keyof CreateUserPayload | undefined;
+			if (field && !fieldErrors[field]) {
+				fieldErrors[field] = issue.message;
+			}
+		}
+		return fieldErrors;
+	}, [createUserSubmitAttempted, createUserValidation]);
 
 	useEffect(() => {
 		if (!activeProfile) return;
@@ -564,6 +571,7 @@ export default function SettingsPage({
 			role: 'STUDENT',
 			isBanned: false,
 		});
+		setCreateUserSubmitAttempted(false);
     setCreateUserDialogError(null);
 		setAdminActionSuccess(
 			`User "${created.username}" created successfully (ID: ${created.id})`
@@ -1233,7 +1241,7 @@ export default function SettingsPage({
 				onChange={updateNewUserForm}
 				loading={adminLoading}
 				error={createUserDialogError}
-        validationMessage={createUserDisplayMessage}
+				fieldErrors={createUserFieldErrors}
 			/>
 		</div>
 	);

--- a/services/web/src/features/auth/ui/settings/components/CreateUserDialog.tsx
+++ b/services/web/src/features/auth/ui/settings/components/CreateUserDialog.tsx
@@ -15,7 +15,9 @@ type CreateUserDialogProps = {
   onChange: (key: string, value: any) => void;
   loading: boolean;
   error?: string | null;
-  validationMessage?: string | null;
+  fieldErrors?: Partial<
+    Record<"username" | "fullName" | "overflowEmail" | "bio" | "role" | "isBanned", string>
+  >;
 };
 
 export default function CreateUserDialog({
@@ -26,10 +28,13 @@ export default function CreateUserDialog({
   onChange,
   loading,
   error,
-  validationMessage,
+  fieldErrors,
 }: CreateUserDialogProps) {
   if (!open) return null;
-  const formError = error ?? validationMessage;
+  const formError = error ?? null;
+  const fieldErrorList = fieldErrors
+    ? Object.values(fieldErrors).filter(Boolean)
+    : [];
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
       <div className="bg-base-100 rounded-lg shadow-lg w-full max-w-2xl p-6 relative">
@@ -122,6 +127,13 @@ export default function CreateUserDialog({
               </div>
             </label>
           </div>
+          {fieldErrorList.length > 0 && (
+            <div className="mt-3 text-xs text-error space-y-1">
+              {fieldErrorList.map((message, index) => (
+                <p key={`${message}-${index}`}>{message}</p>
+              ))}
+            </div>
+          )}
           {formError && <p className="text-xs text-error mt-3">{formError}</p>}
           <div className="flex items-center justify-between pt-6 mt-6 border-t border-base-200">
             <span className="text-xs text-base-content/40">All fields required unless marked optional.</span>

--- a/services/web/src/features/auth/validation/authSchemas.ts
+++ b/services/web/src/features/auth/validation/authSchemas.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { AVATAR_MAX_BYTES } from '@/features/auth/utils/avatarFile'
 
 const usernamePattern = /^[a-zA-Z0-9_-]+$/
-const fullNamePattern = usernamePattern
+const fullNamePattern = /^[a-zA-Z0-9_ -]+$/
 const strongPasswordPattern = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,128}$/
 export const passwordSchema = z
   .string()
@@ -81,7 +81,7 @@ export const passwordChangeSchema = z
       .max(100, "Full name must be between 1 and 100 characters")
       .regex(
         fullNamePattern,
-        "Full name can only contain letters, numbers, underscores, and hyphens",
+        "Full name can only contain letters, numbers, spaces, underscores, and hyphens",
       )
       .optional()
       .or(z.literal("")),
@@ -116,7 +116,7 @@ export const passwordChangeSchema = z
       .max(100, "Full name must be between 1 and 100 characters")
       .regex(
         fullNamePattern,
-        "Full name can only contain letters, numbers, underscores, and hyphens",
+        "Full name can only contain letters, numbers, spaces, underscores, and hyphens",
       ),
     overflowEmail: z
       .string()

--- a/services/web/src/features/auth/validation/authSchemas.ts
+++ b/services/web/src/features/auth/validation/authSchemas.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { AVATAR_MAX_BYTES } from '@/features/auth/utils/avatarFile'
 
 const usernamePattern = /^[a-zA-Z0-9_-]+$/
+const fullNamePattern = usernamePattern
 const strongPasswordPattern = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,128}$/
 export const passwordSchema = z
   .string()
@@ -78,6 +79,10 @@ export const passwordChangeSchema = z
       .trim()
       .min(1, "Full name is required")
       .max(100, "Full name must be between 1 and 100 characters")
+      .regex(
+        fullNamePattern,
+        "Full name can only contain letters, numbers, underscores, and hyphens",
+      )
       .optional()
       .or(z.literal("")),
     avatarFile: z
@@ -108,7 +113,11 @@ export const passwordChangeSchema = z
       .string()
       .trim()
       .min(1, "Full name is required")
-      .max(100, "Full name must be between 1 and 100 characters"),
+      .max(100, "Full name must be between 1 and 100 characters")
+      .regex(
+        fullNamePattern,
+        "Full name can only contain letters, numbers, underscores, and hyphens",
+      ),
     overflowEmail: z
       .string()
       .trim()


### PR DESCRIPTION
…as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Show per-field validation errors on the admin "Create user" form for clearer, field-specific feedback.
  * Standardized full-name validation across profile update and user-creation flows for more consistent name rules.
  * Improved form error display so field errors appear above general form errors.
  * Reset the create-user submission state after a successful account creation to prevent stale error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->