### PR TITLE
fix: gmail should not be limited to @gmail.com as a domain name, also…

### DIFF
--- a/services/web/src/features/auth/ui/settings/SettingsPage.tsx
+++ b/services/web/src/features/auth/ui/settings/SettingsPage.tsx
@@ -274,6 +274,7 @@ export default function SettingsPage({
     role: "STUDENT",
     isBanned: false,
   });
+  const [pendingNewUserAvatarFile, setPendingNewUserAvatarFile] = useState<File | null>(null);
 
 	const isAdmin = hasRole('ADMIN');
 	const activeProfile = profile ?? user;
@@ -381,6 +382,7 @@ export default function SettingsPage({
     if (!createUserModalOpen) {
       setCreateUserSubmitAttempted(false);
       setCreateUserDialogError(null);
+      setPendingNewUserAvatarFile(null);
     }
   }, [createUserModalOpen]);
 
@@ -536,13 +538,24 @@ export default function SettingsPage({
     setCreateUserDialogError(null);
 		setAdminActionSuccess(null);
 
+		if (pendingNewUserAvatarFile) {
+			const validationError = validateAvatarFile(pendingNewUserAvatarFile);
+			if (validationError) {
+				setCreateUserDialogError(validationError);
+				return;
+			}
+		}
+
+		let avatarFilePayload: string | undefined;
+		if (pendingNewUserAvatarFile) {
+			avatarFilePayload = await fileToDataUrl(pendingNewUserAvatarFile);
+		}
 
 	const parsed = createUserSchema.safeParse(newUserForm);
 	if (!parsed.success) {
 		return;
 	}
 	const { username, fullName, overflowEmail, bio, role, isBanned } = parsed.data;
-
 
     if (!username || !fullName || !overflowEmail) {
       setAdminActionError("Username, full name, and email are required.");
@@ -556,6 +569,7 @@ export default function SettingsPage({
 			bio: bio?.trim() || undefined,
 			role,
 			isBanned,
+			avatarFile: avatarFilePayload,
 		});
 
 		if (!created) {
@@ -571,6 +585,7 @@ export default function SettingsPage({
 			role: 'STUDENT',
 			isBanned: false,
 		});
+		setPendingNewUserAvatarFile(null);
 		setCreateUserSubmitAttempted(false);
     setCreateUserDialogError(null);
 		setAdminActionSuccess(
@@ -1242,6 +1257,8 @@ export default function SettingsPage({
 				loading={adminLoading}
 				error={createUserDialogError}
 				fieldErrors={createUserFieldErrors}
+				onAvatarFileChange={setPendingNewUserAvatarFile}
+				avatarFileName={pendingNewUserAvatarFile?.name ?? null}
 			/>
 		</div>
 	);

--- a/services/web/src/features/auth/ui/settings/components/CreateUserDialog.tsx
+++ b/services/web/src/features/auth/ui/settings/components/CreateUserDialog.tsx
@@ -13,6 +13,8 @@ type CreateUserDialogProps = {
     isBanned: boolean;
   };
   onChange: (key: string, value: any) => void;
+  onAvatarFileChange?: (file: File | null) => void;
+  avatarFileName?: string | null;
   loading: boolean;
   error?: string | null;
   fieldErrors?: Partial<
@@ -26,6 +28,8 @@ export default function CreateUserDialog({
   onSubmit,
   draft,
   onChange,
+  onAvatarFileChange,
+  avatarFileName,
   loading,
   error,
   fieldErrors,
@@ -89,6 +93,21 @@ export default function CreateUserDialog({
                 value={draft.bio ?? ""}
                 onChange={e => onChange("bio", e.target.value)}
               />
+            </label>
+            <label className="flex flex-col gap-1.5 md:col-span-2">
+              <span className="text-[11px] font-bold uppercase tracking-wider text-base-content/50">Avatar</span>
+              <label className="btn btn-outline btn-sm w-full">
+                Choose avatar image
+                <input
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  onChange={(event) => onAvatarFileChange?.(event.target.files?.[0] ?? null)}
+                />
+              </label>
+              {avatarFileName && (
+                <span className="text-xs text-base-content/60 font-medium">Selected: {avatarFileName}</span>
+              )}
             </label>
             <label className="flex flex-col gap-1.5">
               <span className="text-[11px] font-bold uppercase tracking-wider text-base-content/50">Role</span>

--- a/services/web/src/features/auth/validation/authSchemas.ts
+++ b/services/web/src/features/auth/validation/authSchemas.ts
@@ -122,10 +122,13 @@ export const passwordChangeSchema = z
       .string()
       .trim()
       .email("Please enter a valid email")
-      .max(255, "Email must be at most 255 characters")
-      .refine((value) => value.toLowerCase().endsWith("@gmail.com"), {
-        message: "Only @gmail.com addresses are allowed",
-      }),
+      .max(255, "Email must be at most 255 characters"),
+    avatarFile: z
+      .string()
+      .trim()
+      .max(3000000, "Avatar file payload is too large")
+      .optional()
+      .or(z.literal("")),
     bio: z
       .string()
       .trim()


### PR DESCRIPTION
… added avatar to user creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Admins can now upload and assign a profile avatar image when creating new user accounts through the admin settings interface
* Avatar file uploads are limited to a maximum file size of 3MB
* Email validation has been improved: removed the Gmail-only domain restriction to support any standard email address format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->